### PR TITLE
Update schedule for lock file maintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "extends": ["config:base"],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on Tuesday"]
+    "schedule": ["before 6am on tuesday"]
   },
   "major": {
     "automerge": false


### PR DESCRIPTION
In many repositories the lock file maintenance branches do not currently
seem to be automatically merged. I suspect this may be due to our current
schedule of "before 2am" which leaves a too limited time window for
Renovate.