### PR TITLE
Restructure presets to allow use in external organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,26 @@ for some Capra projects.
 See [Configuration Options](https://docs.renovatebot.com/configuration-options/)
 for a complete list of possible options.
 
+## Preset strategy
+
+This central Renovate configuration can be used both by repositories in capralifecycle, and repositories in other
+organizations. This is possible because we split the configuration of credentials, which cannot be referred to or
+even overridden in another organization (see https://github.com/renovatebot/renovate/discussions/26987), into a separate
+preset _with-credentials.json_. This is why there are sets of presets (for example _default-base.json_ and _default.json_)
+with similar names. Internal consumers in the capralifecycle organization can use presets that include both configuration
+and credentials, while external consumers can only use presets specifying configuration, and must define credentials
+separately in their own repository or organization.
+
+1. **External consumers**: Use the presets with the "base" suffix, for example _default-base.json_. These presets
+contain configuration, but not credentials for Github Packages. The consumers must define their own credentials to use with
+Github Packages.
+2. **Internal consumers**: Use the presets without the "base" suffix, for example _default.json_. These presets extend the
+base configuration (for example _default-base.json_) and the preset containing credentials _with-credentials.json_.
+
 ## Usage
 
-For most code bases - using [`default.json`](./default.json):
+For most code bases - using [`default.json`](./default.json) ([`default-base.json`](./default-base.json) for external
+consumers):
 
 ```json
 {
@@ -18,7 +35,8 @@ For most code bases - using [`default.json`](./default.json):
 }
 ```
 
-For libraries - using [`library.json`](./library.json):
+For libraries - using [`library.json`](./library.json) ([`library-base.json`](./library-base.json) for external
+consumers):
 
 ```json
 {
@@ -26,7 +44,8 @@ For libraries - using [`library.json`](./library.json):
 }
 ```
 
-For aggressive merging - using [`aggressive.json`](./aggressive.json):
+For aggressive merging - using [`aggressive.json`](./aggressive.json) ([`aggressive-base.json`](./aggressive-base.json) for external
+consumers):
 
 ```json
 {
@@ -37,7 +56,8 @@ For aggressive merging - using [`aggressive.json`](./aggressive.json):
 This will schedule at any time and automerge as much as possible,
 excluding major updates.
 
-For automerging only within office hours - using [`office-hours.json`](./office-hours.json):
+For automerging only within office hours - using [`office-hours.json`](./office-hours.json)([`office-hours-base.json`](./office-hours-base.json)
+for external consumers):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For most code bases - using [`default.json`](./default.json):
 
 ```json
 {
-  "extends": ["github>capraconsulting/renovate-config:default"]
+  "extends": ["github>capralifecycle/renovate-config:default"]
 }
 ```
 
@@ -22,7 +22,7 @@ For libraries - using [`library.json`](./library.json):
 
 ```json
 {
-  "extends": ["github>capraconsulting/renovate-config:library"]
+  "extends": ["github>capralifecycle/renovate-config:library"]
 }
 ```
 
@@ -30,7 +30,7 @@ For aggressive merging - using [`aggressive.json`](./aggressive.json):
 
 ```json
 {
-  "extends": ["github>capraconsulting/renovate-config:aggressive"]
+  "extends": ["github>capralifecycle/renovate-config:aggressive"]
 }
 ```
 
@@ -41,7 +41,7 @@ For automerging only within office hours - using [`office-hours.json`](./office-
 
 ```json
 {
-  "extends": ["github>capraconsulting/renovate-config:office-hours"]
+  "extends": ["github>capralifecycle/renovate-config:office-hours"]
 }
 ```
 

--- a/aggressive-base.json
+++ b/aggressive-base.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["github>capraconsulting/renovate-config:default-base#ebo"],
+  "automerge": true,
+  "automergeType": "branch",
+  "schedule": ["at any time"]
+}

--- a/aggressive-base.json
+++ b/aggressive-base.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["github>capralifecycle/renovate-config:default-base#ebo"],
+  "extends": ["github>capralifecycle/renovate-config:default-base"],
   "automerge": true,
   "automergeType": "branch",
   "schedule": ["at any time"]

--- a/aggressive-base.json
+++ b/aggressive-base.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["github>capraconsulting/renovate-config:default-base#ebo"],
+  "extends": ["github>capralifecycle/renovate-config:default-base#ebo"],
   "automerge": true,
   "automergeType": "branch",
   "schedule": ["at any time"]

--- a/aggressive.json
+++ b/aggressive.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:aggressive-base#ebo",
-    "github>capralifecycle/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:aggressive-base",
+    "github>capralifecycle/renovate-config:with-credentials"
   ]
 }

--- a/aggressive.json
+++ b/aggressive.json
@@ -1,6 +1,6 @@
 {
-  "extends": ["github>capraconsulting/renovate-config:default"],
-  "automerge": true,
-  "automergeType": "branch",
-  "schedule": ["at any time"]
+  "extends": [
+    "github>capraconsulting/renovate-config:aggressive-base#ebo",
+    "github>capraconsulting/renovate-config:with-credentials#ebo"
+  ]
 }

--- a/aggressive.json
+++ b/aggressive.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:aggressive-base#ebo",
-    "github>capraconsulting/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:aggressive-base#ebo",
+    "github>capralifecycle/renovate-config:with-credentials#ebo"
   ]
 }

--- a/default-base.json
+++ b/default-base.json
@@ -1,0 +1,185 @@
+{
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on tuesday"]
+  },
+  "major": {
+    "automerge": false
+  },
+  "masterIssue": true,
+  "packageRules": [
+    {
+      "packageNames": [
+        "boto3",
+        "aws-sdk"
+      ],
+      "packagePatterns": [
+        "^com.amazonaws:java-sdk-",
+        "^software.amazon.awssdk:"
+      ],
+      "extends": ["schedule:monthly"]
+    },
+    {
+      "packageNames": [
+        "@capraconsulting/sentry-utils-js",
+        "@capraconsulting/validation-utils-js",
+        "autoprefixer",
+        "black",
+        "flake8",
+        "http-server",
+        "jest-each",
+        "jest",
+        "prettier",
+        "react",
+        "react-dom",
+        "semantic-release",
+        "testcafe",
+        "ts-jest",
+        "ts-node",
+        "typescript",
+        "webpack-cli",
+        "webpack-dev-server",
+        "webpack"
+      ],
+      "packagePatterns": [
+        "^@types/",
+        "^@typescript-eslint/",
+        "^tslint",
+        "^eslint",
+        "-loader$",
+        "-webpack-plugin$",
+        "^rollup"
+      ],
+      "automerge": true,
+      "automergeType": "branch",
+      "major": {
+        "automerge": false
+      }
+    },
+    {
+      "packagePatterns": [
+        "^com.fasterxml.jackson."
+      ],
+      "groupName": "jackson packages"
+    },
+    {
+      "packagePatterns": [
+        "^org.testcontainers."
+      ],
+      "groupName": "testcontainers packages"
+    },
+    {
+      "packagePatterns": [
+        "^org.jetbrains.kotlinx:kotlinx-serialization-"
+      ],
+      "groupName": "kotlinx-serialization packages"
+    },
+    {
+      "packagePatterns": [
+        "^software.amazon.awssdk:"
+      ],
+      "groupName": "aws-sdk-java-v2 monorepo"
+    },
+    {
+      "packagePatterns": [
+        "^org.junit.jupiter:",
+        "^org.junit.platform:",
+        "^org.junit.vintage:"
+      ],
+      "groupName": "junit5 packages"
+    },
+    {
+      "packagePatterns": ["^org.http4k:http4k-"],
+      "groupName": "http4k monorepo"
+    },
+    {
+      "packagePatterns": ["^org.jdbi:jdbi3-"],
+      "groupName": "jdbi3 packages"
+    },
+    {
+      "packagePatterns": ["^org.spekframework.spek2:"],
+      "groupName": "spek2 packages"
+    },
+    {
+      "packagePatterns": [
+        "^com.slack.api:"
+      ],
+      "groupName": "slack api packages"
+    },
+    {
+      "packagePatterns": [
+        "^org.jetbrains.kotlin:",
+        "^org.jetbrains.kotlin.\\w+:",
+        "^org.jetbrains.kotlin.plugin.\\w+:"
+      ],
+      "groupName": "kotlin packages"
+    },
+    {
+      "description": "Prevent inheriting any auto-merge of Kotlin minor versions to minimize compatibiliity issues",
+      "packagePatterns": [
+        "^org\\.jetbrains\\.kotlin:",
+        "^org\\.jetbrains\\.kotlin\\.\\w+:",
+        "^org\\.jetbrains\\.kotlin\\.plugin\\.\\w+:",
+        "^org\\.jetbrains\\.kotlinx:"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "automerge": false
+    },
+    {
+      "description": "Avoid updates such as from 0.20.0 to 0.20.0-1.3.70-eap-274-2",
+      "packagePatterns": [
+        "^org\\.jetbrains\\.kotlinx:"
+      ],
+      "versioning": "semver"
+    },
+    {
+      "description": "Update internal deps at any time",
+      "packagePatterns": [
+        "^@capraconsulting/",
+        "^@liflig/",
+        "^no\\.liflig(:|\\.)"
+      ],
+      "schedule": ["at any time"],
+      "stabilityDays": 0
+    },
+    {
+      "matchPackageNames": ["ts-jest", "@types/jest"],
+      "groupName": "jest monorepo"
+    },
+    {
+      "description": "Pin colors package to non-malicious version",
+      "allowedVersions": "<= 1.4.0",
+      "matchPackageNames": ["colors"]
+    },
+    {
+      "description": "Pin faker.js package to non-malicious version",
+      "allowedVersions": "<= 5.5.3",
+      "matchPackageNames": ["faker"]
+    },
+    {
+      "description": "Pin xlsx package to version that don't crash browser: out of memory",
+      "allowedVersions": "<= 0.18.0",
+      "matchPackageNames": ["xlsx"]
+    },
+    {
+      "description": "Update github actions library at any time",
+      "matchPackageNames": ["capralifecycle/actions-lib"],
+      "enabledManagers": ["github-actions"],
+      "stabilityDays": 0,
+      "schedule": ["at any time"]
+    }
+  ],
+  "pin": {
+    "automerge": true
+  },
+  "prCreation": "not-pending",
+  "schedule": ["before 6am", "every weekend"],
+  "semanticCommits": "enabled",
+  "stabilityDays": 3,
+  "prNotPendingHours": 74,
+  "timezone": "Europe/Oslo"
+}

--- a/default-base.json
+++ b/default-base.json
@@ -25,8 +25,8 @@
     },
     {
       "packageNames": [
-        "@capraconsulting/sentry-utils-js",
-        "@capraconsulting/validation-utils-js",
+        "@capralifecycle/sentry-utils-js",
+        "@capralifecycle/validation-utils-js",
         "autoprefixer",
         "black",
         "flake8",

--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:default-base#ebo",
-    "github>capralifecycle/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:default-base",
+    "github>capralifecycle/renovate-config:with-credentials"
   ]
 }

--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:default-base#ebo",
-    "github>capraconsulting/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:default-base#ebo",
+    "github>capralifecycle/renovate-config:with-credentials#ebo"
   ]
 }

--- a/library-base.json
+++ b/library-base.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:default-base#ebo",
+    "github>capralifecycle/renovate-config:default-base",
     ":pinOnlyDevDependencies"
   ],
   "lockFileMaintenance": {

--- a/library-base.json
+++ b/library-base.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:default",
+    "github>capralifecycle/renovate-config:default-base#ebo",
     ":pinOnlyDevDependencies"
   ],
   "lockFileMaintenance": {

--- a/library-base.json
+++ b/library-base.json
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "github>capraconsulting/renovate-config:default",
+    ":pinOnlyDevDependencies"
+  ],
+  "lockFileMaintenance": {
+    "automerge": true,
+    "automergeType": "branch"
+  }
+}

--- a/library.json
+++ b/library.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "github>capralifecycle/renovate-config:library-base",
-    "github>capralifecycle/renovate-config:with-credentials",
-    ":pinOnlyDevDependencies"
+    "github>capralifecycle/renovate-config:with-credentials"
   ]
 }

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:library-base#ebo",
-    "github>capralifecycle/renovate-config:with-credentials#ebo",
+    "github>capralifecycle/renovate-config:library-base",
+    "github>capralifecycle/renovate-config:with-credentials",
     ":pinOnlyDevDependencies"
   ]
 }

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:library-base#ebo",
-    "github>capraconsulting/renovate-config:with-credentials#ebo",
+    "github>capralifecycle/renovate-config:library-base#ebo",
+    "github>capralifecycle/renovate-config:with-credentials#ebo",
     ":pinOnlyDevDependencies"
   ]
 }

--- a/library.json
+++ b/library.json
@@ -1,10 +1,7 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:default",
+    "github>capraconsulting/renovate-config:library-base#ebo",
+    "github>capraconsulting/renovate-config:with-credentials#ebo",
     ":pinOnlyDevDependencies"
-  ],
-  "lockFileMaintenance": {
-    "automerge": true,
-    "automergeType": "branch"
-  }
+  ]
 }

--- a/office-hours-base.json
+++ b/office-hours-base.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:default-base#ebo",
-    "github>capralifecycle/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:default-base",
+    "github>capralifecycle/renovate-config:with-credentials"
   ],
   "automergeSchedule": ["after 8am and before 10am every weekday"]
 }

--- a/office-hours-base.json
+++ b/office-hours-base.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:default-base",
-    "github>capralifecycle/renovate-config:with-credentials"
+    "github>capralifecycle/renovate-config:default-base"
   ],
   "automergeSchedule": ["after 8am and before 10am every weekday"]
 }

--- a/office-hours-base.json
+++ b/office-hours-base.json
@@ -2,5 +2,6 @@
   "extends": [
     "github>capraconsulting/renovate-config:default-base#ebo",
     "github>capraconsulting/renovate-config:with-credentials#ebo"
-  ]
+  ],
+  "automergeSchedule": ["after 8am and before 10am every weekday"]
 }

--- a/office-hours-base.json
+++ b/office-hours-base.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:default-base#ebo",
-    "github>capraconsulting/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:default-base#ebo",
+    "github>capralifecycle/renovate-config:with-credentials#ebo"
   ],
   "automergeSchedule": ["after 8am and before 10am every weekday"]
 }

--- a/office-hours.json
+++ b/office-hours.json
@@ -1,4 +1,6 @@
 {
-  "extends": ["github>capraconsulting/renovate-config:default"],
-  "automergeSchedule": ["after 8am and before 10am every weekday"]
+  "extends": [
+    "github>capraconsulting/renovate-config:office-hours-base#ebo",
+    "github>capraconsulting/renovate-config:with-credentials#ebo"
+  ]
 }

--- a/office-hours.json
+++ b/office-hours.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:office-hours-base#ebo",
-    "github>capraconsulting/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:office-hours-base#ebo",
+    "github>capralifecycle/renovate-config:with-credentials#ebo"
   ]
 }

--- a/office-hours.json
+++ b/office-hours.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capralifecycle/renovate-config:office-hours-base#ebo",
-    "github>capralifecycle/renovate-config:with-credentials#ebo"
+    "github>capralifecycle/renovate-config:office-hours-base",
+    "github>capralifecycle/renovate-config:with-credentials"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/capraconsulting/renovate-config.git"
+    "url": "git+https://github.com/capralifecycle/renovate-config.git"
   },
   "author": "Capra Consulting",
   "license": "Apache 2.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>capraconsulting/renovate-config:default"
+    "github>capralifecycle/renovate-config:default"
   ],
   "automerge": true,
   "automergeType": "branch"

--- a/with-credentials.json
+++ b/with-credentials.json
@@ -1,0 +1,16 @@
+{
+  "encrypted": {
+    "npmToken": "wcFMA/xDdHCJBTolAQ//Uu9YXnfMezsKwXpG/G4/pYlwDr9N70oyRNIwa2/kqoz9IPzfTZQA41ihjlxQRtPT0Es35xd/7aX3kvAd0CNet5aYhnbWg+cU3CrsSq3+Oke+HPabtpBHj8erQUuAwkycKcli9nuhJ7H7/yRco1vsPTLFAjLGFft8ipMNA5kH578riSI5BSxag0Jisi4EAnZbVlWTj29v8GcAcrYzJoOQnbVYM65qxlwTmSueI06/Omh3XIHdz9kQsMV0mJD0lH1qkxhS2KJE0+zjYvgmhh/ZZqDfC94UpOlO/BZjOhaBKFVVX1+R88V4tMxlSiNIpdXbwjPpQAEVhgJ5V+TA/T+iG8Zl/2ala89h0sEKvkHJJi1YWf6IYLXHS9I0LI5dgM8vA6LOs3DUyw/nFbXxcnqyQM2+WTqsxNDuHL6ablmUPtMk98e71gNK/BbgxFxmc6qmWarq0ye5WbP1ZT2bC+fFbd2uFlB0kFONBAW3euNcTr8B1OJr+IyIzyfaThXdvAxDrLJFi4At0aDQjPAU43qbRa3ipWaVpk+pBHggMimQh0FbO9SuZkSRE7rM8qAdPZrct5ewZICJccSycVo3oDY4xXFK7S4SHhI9oMkdzxJaji4I4wjzgtRAysjJCXLLKcCfg1qdpB7GzZonScPuM0FuPMnq6MI6Sy3aKaaOKqQj+9DSfQHuEW/UMqewZzW3ZQsxlq2xqJqxCB/A6wU3O+aUcqUf/HNjLZDPo0dgvOGH2Tu88K/XGV1YmghEZr26DNzvmj6GBsFo6kUf7mbLwiRUg8Y+GXLig12foso4wvDvLso2mHvAhWkjw2D955Qm3/h4pK9KRqqhRc2hmpA1O9qk"
+  },
+  "npmrc": "registry=https://registry.npmjs.org/\n@capralifecycle:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${NPM_TOKEN}",
+  "npmrcMerge": true,
+  "hostRules": [
+    {
+      "hostType": "maven",
+      "baseUrl": "https://maven.pkg.github.com",
+      "encrypted": {
+        "token": "wcFMA/xDdHCJBTolAQ//Uu9YXnfMezsKwXpG/G4/pYlwDr9N70oyRNIwa2/kqoz9IPzfTZQA41ihjlxQRtPT0Es35xd/7aX3kvAd0CNet5aYhnbWg+cU3CrsSq3+Oke+HPabtpBHj8erQUuAwkycKcli9nuhJ7H7/yRco1vsPTLFAjLGFft8ipMNA5kH578riSI5BSxag0Jisi4EAnZbVlWTj29v8GcAcrYzJoOQnbVYM65qxlwTmSueI06/Omh3XIHdz9kQsMV0mJD0lH1qkxhS2KJE0+zjYvgmhh/ZZqDfC94UpOlO/BZjOhaBKFVVX1+R88V4tMxlSiNIpdXbwjPpQAEVhgJ5V+TA/T+iG8Zl/2ala89h0sEKvkHJJi1YWf6IYLXHS9I0LI5dgM8vA6LOs3DUyw/nFbXxcnqyQM2+WTqsxNDuHL6ablmUPtMk98e71gNK/BbgxFxmc6qmWarq0ye5WbP1ZT2bC+fFbd2uFlB0kFONBAW3euNcTr8B1OJr+IyIzyfaThXdvAxDrLJFi4At0aDQjPAU43qbRa3ipWaVpk+pBHggMimQh0FbO9SuZkSRE7rM8qAdPZrct5ewZICJccSycVo3oDY4xXFK7S4SHhI9oMkdzxJaji4I4wjzgtRAysjJCXLLKcCfg1qdpB7GzZonScPuM0FuPMnq6MI6Sy3aKaaOKqQj+9DSfQHuEW/UMqewZzW3ZQsxlq2xqJqxCB/A6wU3O+aUcqUf/HNjLZDPo0dgvOGH2Tu88K/XGV1YmghEZr26DNzvmj6GBsFo6kUf7mbLwiRUg8Y+GXLig12foso4wvDvLso2mHvAhWkjw2D955Qm3/h4pK9KRqqhRc2hmpA1O9qk"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The goal here is that repos in a client organization can use Liflig's central Renovate configuration. This is currently not possible because all our central configuration uses encrypted values that can only be decrypted from our GitHub organization - see https://github.com/renovatebot/renovate/discussions/26987. 

In order for consumers outside of Liflig's GitHub organization to use the configuration, we restructure the configuration so that internal consumers can use, for example, default.json, which includes credentials, while external consumers can use default-base.json and define their own credentials.