### PR TITLE
Process forked repositories

### DIFF
--- a/default-base.json
+++ b/default-base.json
@@ -181,5 +181,6 @@
   "semanticCommits": "enabled",
   "stabilityDays": 3,
   "prNotPendingHours": 74,
-  "timezone": "Europe/Oslo"
+  "timezone": "Europe/Oslo",
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
Enables processing of forked repositories. We have a few repositories not currently being processed, as forks by default are ignored.

It's also possible to configure this per repository, but given that we manage Renovate at an organization level, I believe configuring this in the base more closely aligns with the behavior expected by the developers, but I'm open to suggestions.

Docs: https://docs.renovatebot.com/configuration-options/#forkprocessing