### PR TITLE
Remove fork processing from default-base

### DIFF
--- a/default-base.json
+++ b/default-base.json
@@ -181,6 +181,5 @@
   "semanticCommits": "enabled",
   "stabilityDays": 3,
   "prNotPendingHours": 74,
-  "timezone": "Europe/Oslo",
-  "forkProcessing": "enabled"
+  "timezone": "Europe/Oslo"
 }


### PR DESCRIPTION
Renovate doesn't seem to be able to process forks when it is enabled in an inherited config. Moving to top level configs instead