### PR TITLE
Extend office hours to 1pm

### DIFF
--- a/office-hours-base.json
+++ b/office-hours-base.json
@@ -2,5 +2,5 @@
   "extends": [
     "github>capralifecycle/renovate-config:default-base"
   ],
-  "automergeSchedule": ["after 8am and before 10am every weekday"]
+  "automergeSchedule": ["after 8am and before 1pm every weekday"]
 }


### PR DESCRIPTION
The current window of 2 hours seems too narrow to give Renovate enough time for merging updates