### PR TITLE
feat: add github actions config

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -1,0 +1,25 @@
+{
+  "description": "Manages GitHub Actions updates",
+  "packageRules": [
+    {
+      "description": "Core GitHub Actions updates",
+      "groupSlug": "github-actions-core",
+      "matchPackageNames": [
+        "actions/cache",
+        "actions/checkout",
+        "actions/configure-pages",
+        "actions/deploy-pages",
+        "actions/download-artifact",
+        "actions/github-script",
+        "actions/setup-java",
+        "actions/setup-node",
+        "actions/setup-python",
+        "actions/upload-artifact",
+        "actions/upload-pages-artifact"
+      ],
+      "enabledManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ]
+}


### PR DESCRIPTION
In a step towards a more modular configuration, add a separate github
actions configuration that as of now allows automerging of updates to
the official actions
