### PR TITLE
fix: ignore vendor-specific keywords in validation

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCHEMA="renovate-schema.json"
+
 echo "Fetching latest JSON Schema"
-curl -s https://docs.renovatebot.com/renovate-schema.json >renovate-schema.json
+curl -s "https://docs.renovatebot.com/$SCHEMA" > "$SCHEMA"
 
 # As of this writing, Renovate uses draft-04 which is
 # too old for the validate command of ajv.
-echo "Migrating schema to newer version"
-npx ajv migrate -s renovate-schema.json
+echo "Migrating schema [${SCHEMA}] to newer version"
+npx ajv migrate -s "$SCHEMA"
 
 echo "Now validating.."
 
 for x in *.json; do
   if [[ "$x" != "package.json" && "$x" != "package-lock.json" ]]; then
-    echo "Validating $x"
-    npx ajv -s renovate-schema.json -d "$x" -c ajv-formats
+    echo "Validating $x .."
+    npx ajv -s "$SCHEMA" -d "$x" -c ajv-formats --strict-schema=false
   fi
 done


### PR DESCRIPTION
Renovate added a new key `"x-renovate-version"` to their [schema](https://docs.renovatebot.com/renovate-schema.json), which [broke our strict validation](https://github.com/capralifecycle/renovate-config/actions/runs/18559956018/job/52906240848).

This change keeps strict validation of our own data, while ignoring vendor-specific keywords like this.

