### PR TITLE
Limit renovate to only auto merge PRs on same schedule as updates

### DIFF
--- a/grouped-patch-friday.json
+++ b/grouped-patch-friday.json
@@ -9,6 +9,7 @@
   "timezone": "Europe/Oslo",
   "minimumReleaseAge": "3 days",
   "schedule": "* 5-13 * * 5",
+  "automergeSchedule": "* 5-13 * * 5",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
This is only done to make it easier to reason about how Renovate works
