### PR TITLE
hsk/tmp

### DIFF
--- a/grouped-patch-friday.json
+++ b/grouped-patch-friday.json
@@ -10,18 +10,12 @@
 
   "minimumReleaseAge": "3 days",
 
-  // Only allows branch creation on Saturday and Sunday. Avoids churn and
-  // makes sure all updates are prepared for Monday.
   "schedule": ["* * * * 0,6"],
 
-  // Disabled so Renovate controls automerge timing and respects automergeSchedule.
   "platformAutomerge": false,
 
-  // This is the default value. It allows rebasing and force pushing new versions to
-  // existing branches outside the `schedule`. Included here just documentating the behavior.
   "updateNotScheduled": true,
 
-  // Auto-merge in working hours on Mondays.
   "automergeSchedule": ["* 6-14 * * 1"],
 
   "lockFileMaintenance": {

--- a/grouped-patch-friday.json5
+++ b/grouped-patch-friday.json5
@@ -28,5 +28,14 @@
     "enabled": true,
     "automerge": true,
     "schedule": ["* * * * 0,6"]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Lock file maintenance PRs do not have releaseTimestamp",
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "minimumReleaseAge": null
+    }
+  ]
 }


### PR DESCRIPTION
- **Lock file maintenance PRs should not have minimumReleaseAge**
- **Fix: rename back to .json**
